### PR TITLE
Fix invalid tar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- If a file contained a single line with more than `512` characters it wasn't properly encoded in a `tar` file.
+
 ## 1.0.0 - 2023-10-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - If a file contained a single line with more than `512` characters it wasn't properly encoded in a `tar` file.
+- Last modification date of files encoded in a `tar` file were set in the future.
 
 ## 1.0.0 - 2023-10-29
 

--- a/proofs/tar.php
+++ b/proofs/tar.php
@@ -10,7 +10,10 @@ use Innmind\Filesystem\{
 };
 use Innmind\TimeContinuum\Earth;
 use Innmind\Url\Path;
-use Innmind\Immutable\Predicate\Instance;
+use Innmind\Immutable\{
+    Str,
+    Predicate\Instance,
+};
 use Innmind\BlackBox\Set;
 use Fixtures\Innmind\Filesystem\{
     Directory as FDirectory,
@@ -193,10 +196,18 @@ return static function() {
 
     yield proof(
         'Tar encode any shape of file/directory',
-        given(Set\Either::any(
-            FFile::any(),
-            FDirectory::any(),
-        )),
+        given(
+            Set\Either::any(
+                FFile::any(),
+                FDirectory::any(),
+            )->filter(
+                static fn($file) => $file
+                    ->name()
+                    ->str()
+                    ->toEncoding(Str\Encoding::ascii)
+                    ->length() < 251, // otherwise the `.tar` extension will overflow
+            ),
+        ),
         static function($assert, $file) {
             $clock = new Earth\Clock;
             $path = \rtrim(\sys_get_temp_dir(), '/').'/innmind/encoding/';

--- a/proofs/tar.php
+++ b/proofs/tar.php
@@ -213,6 +213,12 @@ return static function() {
                         ->name()
                         ->str()
                         ->contains(':'), // if preceded by a letter the tar command will remove the `:` as it interprets it as a windows drive path
+                )
+                ->filter(
+                    static fn($file) => !$file
+                        ->name()
+                        ->str()
+                        ->startsWith('\\'), // the tar command removes leading backslashes
                 ),
         ),
         static function($assert, $file) {

--- a/proofs/tar.php
+++ b/proofs/tar.php
@@ -200,13 +200,20 @@ return static function() {
             Set\Either::any(
                 FFile::any(),
                 FDirectory::any(),
-            )->filter(
-                static fn($file) => $file
-                    ->name()
-                    ->str()
-                    ->toEncoding(Str\Encoding::ascii)
-                    ->length() < 251, // otherwise the `.tar` extension will overflow
-            ),
+            )
+                ->filter(
+                    static fn($file) => $file
+                        ->name()
+                        ->str()
+                        ->toEncoding(Str\Encoding::ascii)
+                        ->length() < 251, // otherwise the `.tar` extension will overflow
+                )
+                ->filter(
+                    static fn($file) => !$file
+                        ->name()
+                        ->str()
+                        ->contains(':'), // if preceded by a letter the tar command will remove the `:` as it interprets it as a windows drive path
+                ),
         ),
         static function($assert, $file) {
             $clock = new Earth\Clock;

--- a/proofs/tar.php
+++ b/proofs/tar.php
@@ -5,12 +5,17 @@ use Innmind\Encoding\Tar;
 use Innmind\Filesystem\{
     Adapter\Filesystem,
     Name,
+    File,
     Directory,
 };
 use Innmind\TimeContinuum\Earth;
 use Innmind\Url\Path;
 use Innmind\Immutable\Predicate\Instance;
 use Innmind\BlackBox\Set;
+use Fixtures\Innmind\Filesystem\{
+    Directory as FDirectory,
+    File as FFile,
+};
 
 return static function() {
     yield proof(
@@ -183,6 +188,62 @@ return static function() {
                         static fn() => null,
                     ),
             );
+        },
+    );
+
+    yield proof(
+        'Tar encode any shape of file/directory',
+        given(Set\Either::any(
+            FFile::any(),
+            FDirectory::any(),
+        )),
+        static function($assert, $file) {
+            $clock = new Earth\Clock;
+            $path = \rtrim(\sys_get_temp_dir(), '/').'/innmind/encoding/';
+            $tmp = Filesystem::mount(Path::of($path));
+            $tar = Tar::encode($clock)($file);
+            $tmp->add($tar);
+
+            $exitCode = null;
+            $name = $path.$tar->name()->toString();
+            $name = \str_replace("'", "'\\''", $name);
+            \exec("tar -xf '$name' --directory=$path", result_code: $exitCode);
+            $assert->same(0, $exitCode);
+
+            if ($file instanceof File) {
+                $assert->same(
+                    $file->content()->toString(),
+                    $tmp
+                        ->get($file->name())
+                        ->keep(Instance::of(File::class))
+                        ->match(
+                            static fn($file) => $file->content()->toString(),
+                            static fn() => null,
+                        ),
+                );
+
+                return;
+            }
+
+            $assert->true($tmp->contains($file->name()));
+            // for simplicity no recursive assertions on nested directories
+            $file
+                ->all()
+                ->keep(Instance::of(File::class))
+                ->foreach(
+                    static fn($expected) => $assert->same(
+                        $expected->content()->toString(),
+                        $tmp
+                            ->get($file->name())
+                            ->keep(Instance::of(Directory::class))
+                            ->flatMap(static fn($found) => $found->get($expected->name()))
+                            ->keep(Instance::of(File::class))
+                            ->match(
+                                static fn($found) => $found->content()->toString(),
+                                static fn() => null,
+                            ),
+                    ),
+                );
         },
     );
 };

--- a/src/Tar/Encode.php
+++ b/src/Tar/Encode.php
@@ -163,7 +163,7 @@ final class Encode
                 \sprintf('%07s', \decoct(0)), // user id
                 \sprintf('%07s', \decoct(0)), // group id
                 \sprintf('%011s', \decoct($size)), // file size
-                \sprintf('%011s', \decoct($this->clock->now()->milliseconds())), // file last modification time
+                \sprintf('%011s', \decoct((int) ($this->clock->now()->milliseconds() / 1000))), // file last modification time
             ),
             Str\Encoding::ascii,
         );

--- a/src/Tar/Encode.php
+++ b/src/Tar/Encode.php
@@ -118,6 +118,7 @@ final class Encode
                 ->chunks()
                 ->map(static fn($chunk) => $chunk->toEncoding(Str\Encoding::ascii))
                 ->aggregate(static fn(Str $a, Str $b) => $a->append($b)->chunk(512))
+                ->flatMap(static fn($str) => $str->chunk(512)) // in case there is only one line
                 ->map(static fn($chunk) => \pack('a512', $chunk->toString()))
                 ->map(static fn($chunk) => Str::of($chunk, Str\Encoding::ascii)),
         );


### PR DESCRIPTION
## Problem

The proofs consistently fail when tar encoding a directory with the `amqp.pdf` fixture.

After investigation the encoding fails to correctly chunk a file in pieces of `512` chars when the file only contains 1 line longer than that.

## Solution

- Apply a post chunk after the aggregation to make sure the case is covered when there is only one line
- Add a proof to test a wider variety of files/directories to encode
- Fixed the last modification time that was set in the future (discovered in the CI of this PR)