### PR TITLE
Remove file to archive to prevent collisions between scenarii

### DIFF
--- a/proofs/tar.php
+++ b/proofs/tar.php
@@ -227,6 +227,10 @@ return static function() {
             $clock = new Earth\Clock;
             $path = \rtrim(\sys_get_temp_dir(), '/').'/innmind/encoding/';
             $tmp = Filesystem::mount(Path::of($path));
+
+            // make sure to avoid conflicts when trying to unarchive
+            $tmp->remove($file->name());
+
             $tar = Tar::encode($clock)($file);
             $tmp->add($tar);
 


### PR DESCRIPTION
This is due to the use of `tar` command to proove the code that may error when the file to unarchive already exist from a previous scenario