### PR TITLE
Add regression case due to invalid utf8 content

### DIFF
--- a/proofs/tar.php
+++ b/proofs/tar.php
@@ -270,4 +270,40 @@ return static function() {
                 );
         },
     );
+
+    yield test(
+        'Tar encode files with utf8 content',
+        static function($assert) {
+            $clock = Clock::live();
+            $path = \rtrim(\sys_get_temp_dir(), '/').'/innmind/encoding/';
+            $tmp = Filesystem::mount(Path::of($path));
+
+            $file = File::named(
+                '._+',
+                File\Content::ofString('›'),
+            );
+
+            // make sure to avoid conflicts when trying to unarchive
+            $tmp->remove($file->name());
+
+            $tar = Tar::encode($clock)($file);
+            $tar = File::named('shape.tar', $tar);
+            $tmp->add($tar);
+
+            $exitCode = null;
+            \exec("tar -xf '$path/shape.tar' --directory=$path", result_code: $exitCode);
+            // $assert->same(0, $exitCode);
+
+            $assert->same(
+                $file->content()->toString(),
+                $tmp
+                    ->get($file->name())
+                    ->keep(Instance::of(File::class))
+                    ->match(
+                        static fn($file) => $file->content()->toString(),
+                        static fn() => null,
+                    ),
+            );
+        },
+    )->tag(\Innmind\BlackBox\Tag::wip);
 };

--- a/src/Tar/Encode.php
+++ b/src/Tar/Encode.php
@@ -112,6 +112,9 @@ final class Encode
             ->content()
             ->chunks()
             ->map(static fn($chunk) => $chunk->toEncoding(Str\Encoding::ascii))
+            ->map(static fn($chunk) => $chunk->map(
+                static fn($value) => \mb_convert_encoding($value, 'UTF-8'),
+            ))
             ->aggregate(static fn(Str $a, Str $b) => $a->append($b)->chunk(512))
             ->flatMap(static fn($str) => $str->chunk(512)) // in case there is only one line
             ->map(static fn($chunk) => \pack('a512', $chunk->toString()))


### PR DESCRIPTION
This was detected by BlackBox but I don't know how to fix this as this case is not handled by https://packagist.org/packages/pear/archive_tar